### PR TITLE
adjust cleanup_days_interval

### DIFF
--- a/lib/spree/garbage_cleaner_configuration.rb
+++ b/lib/spree/garbage_cleaner_configuration.rb
@@ -1,6 +1,6 @@
 class Spree::GarbageCleanerConfiguration < Spree::Preferences::Configuration
   preference :models_with_garbage, :any, default: 'Spree::Order'
   preference :timestamp_column, :string, default: 'created_at'
-  preference :cleanup_days_interval, :integer, default: 7
+  preference :cleanup_days_interval, :integer, default: 14
   preference :batch_size, :integer, default: 100
 end


### PR DESCRIPTION
changes cleanup_days_interval from 7 to 14 since orders > 2 weeks old is our criteria for garbage orders
